### PR TITLE
Fix sidebar links for "me, elsewhere"

### DIFF
--- a/source/_side_bar.html.erb
+++ b/source/_side_bar.html.erb
@@ -32,9 +32,9 @@ blog: blog
     </div>
     <div class="panel-body">
       <ul>
-        <li><a href="www.twitter.com/nikkilizmurray">Twitter</a></li>
-        <li><a href="www.github.com/jdax">Github</a></li>
-        <li><a href="www.linkedin.com/in/nicolelizmurray">LinkedIn</a></li>
+        <li><a href="http://www.twitter.com/nikkilizmurray">Twitter</a></li>
+        <li><a href="http://www.github.com/jdax">GitHub</a></li>
+        <li><a href="http://www.linkedin.com/in/nicolelizmurray">LinkedIn</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
I noticed these were broken; they were pointing to 
- http://nikkilizmurray.com/www.twitter.com/nikkilizmurray
- http://nikkilizmurray.com/www.github.com/jdax
- http://nikkilizmurray.com/www.linkedin.com/in/nicolelizmurray

I’m not a Ruby and/or Middleman user, so I wasn’t able to get a working local build to confirm that this really fixes the problem. But this seemed like a plausible fix.
